### PR TITLE
fix(vllm): map renamed vLLM metrics so KV-cache + TPOT populate again

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,12 @@ optional agent-driven NTP probe (default `time.cloudflare.com`,
 opt-out via `timesync.server: ""`) with new soft degraded reason
 `clock_offset_high`. All v0.2.x additions are additive; v0.2.11 is
 the first to introduce a config knob (handled gracefully by the
-existing migrator's missing-top-key detection).
+existing migrator's missing-top-key detection). v0.2.12 maps the
+vLLM metric names that ≥0.6 renamed (`kv_cache_usage_perc`,
+`prefix_cache_hits_total` / `prefix_cache_queries_total`,
+`request_time_per_output_token_seconds`) with backward-compat
+fallback to the legacy names, so `kv_cache` and `tpot` populate
+again on current GB10 nodes. No wire-contract or config change.
 [spec/SPEC.md](spec/SPEC.md) is the authoritative wire contract (any
 change there is a cross-repo break). [spec/V0_2_0_PLAN.md](spec/V0_2_0_PLAN.md)
 records the v0.2.0 design; [PLAN.md](PLAN.md) captures the original v0.1.0

--- a/docs/platforms/vllm.md
+++ b/docs/platforms/vllm.md
@@ -25,11 +25,19 @@ just deprioritizing.
 
 ## Histogram → percentile
 
-vLLM exposes `time_to_first_token_seconds`, `time_per_output_token_seconds`,
-and `e2e_request_latency_seconds` as histograms. The agent computes p50
-and p99 via linear interpolation between bucket edges (the same algorithm
-Prometheus's `histogram_quantile` uses). Returned in `/health` as
-milliseconds for convenience.
+vLLM exposes `time_to_first_token_seconds`, the per-output-token latency
+histogram, and `e2e_request_latency_seconds` as histograms. The agent
+computes p50 and p99 via linear interpolation between bucket edges (the
+same algorithm Prometheus's `histogram_quantile` uses). Returned in
+`/health` as milliseconds for convenience.
+
+vLLM ≥0.6 renamed the per-output-token histogram
+`time_per_output_token_seconds` → `request_time_per_output_token_seconds`
+(and `gpu_cache_usage_perc` → `kv_cache_usage_perc`, and replaced the
+`gpu_prefix_cache_hit_rate` gauge with `prefix_cache_hits_total` /
+`prefix_cache_queries_total` counters). The agent reads the new names
+first and falls back to the legacy names, so both old and new vLLM nodes
+populate `kv_cache` and `tpot`.
 
 If you need other quantiles, scrape `/metrics` directly and compute in
 PromQL — the agent only surfaces p50/p99 to keep `/health` payload small.

--- a/internal/platforms/vllm/promparse_test.go
+++ b/internal/platforms/vllm/promparse_test.go
@@ -83,6 +83,91 @@ func TestHistogramQuantile_AbsentReturnsFalse(t *testing.T) {
 	}
 }
 
+// vLLM ≥0.6 metric exposition: kv_cache_usage_perc gauge,
+// prefix_cache_hits_total/queries_total counters, and the renamed
+// request_time_per_output_token_seconds histogram.
+const sampleV06 = `# HELP vllm:kv_cache_usage_perc KV cache usage [0..1].
+# TYPE vllm:kv_cache_usage_perc gauge
+vllm:kv_cache_usage_perc{model_name="qwen3-vl:32b"} 0.5
+# HELP vllm:prefix_cache_hits_total Prefix cache hits.
+# TYPE vllm:prefix_cache_hits_total counter
+vllm:prefix_cache_hits_total{model_name="qwen3-vl:32b"} 80
+# HELP vllm:prefix_cache_queries_total Prefix cache queries.
+# TYPE vllm:prefix_cache_queries_total counter
+vllm:prefix_cache_queries_total{model_name="qwen3-vl:32b"} 100
+# HELP vllm:request_time_per_output_token_seconds TPOT.
+# TYPE vllm:request_time_per_output_token_seconds histogram
+vllm:request_time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.01"} 0
+vllm:request_time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.02"} 50
+vllm:request_time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.05"} 90
+vllm:request_time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.1"} 99
+vllm:request_time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="+Inf"} 100
+vllm:request_time_per_output_token_seconds_sum{model_name="qwen3-vl:32b"} 2.0
+vllm:request_time_per_output_token_seconds_count{model_name="qwen3-vl:32b"} 100
+`
+
+// Pre-0.6 exposition: the legacy gauge names + time_per_output_token_seconds.
+// Same observable values as sampleV06 so the fallback paths must produce
+// identical Model output.
+const sampleLegacy = `# HELP vllm:gpu_cache_usage_perc KV cache GPU usage [0..1].
+# TYPE vllm:gpu_cache_usage_perc gauge
+vllm:gpu_cache_usage_perc{model_name="qwen3-vl:32b"} 0.5
+# HELP vllm:gpu_prefix_cache_hit_rate Prefix cache hit rate.
+# TYPE vllm:gpu_prefix_cache_hit_rate gauge
+vllm:gpu_prefix_cache_hit_rate{model_name="qwen3-vl:32b"} 0.8
+# HELP vllm:time_per_output_token_seconds TPOT.
+# TYPE vllm:time_per_output_token_seconds histogram
+vllm:time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.01"} 0
+vllm:time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.02"} 50
+vllm:time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.05"} 90
+vllm:time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="0.1"} 99
+vllm:time_per_output_token_seconds_bucket{model_name="qwen3-vl:32b",le="+Inf"} 100
+vllm:time_per_output_token_seconds_sum{model_name="qwen3-vl:32b"} 2.0
+vllm:time_per_output_token_seconds_count{model_name="qwen3-vl:32b"} 100
+`
+
+// buildModel must produce identical kv_cache + tpot output whether the node
+// runs vLLM ≥0.6 (renamed metrics) or an older build (legacy names via the
+// backward-compat fallback). Regression guard for the metric-name drift that
+// silently emptied kv_cache/tpot until v0.2.12.
+func TestBuildModel_MetricRenames(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		metrics string
+	}{
+		{"vllm>=0.6", sampleV06},
+		{"legacy", sampleLegacy},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := vllmModel{ID: "qwen3-vl:32b"}
+			got := buildModel(m, parsePrometheus(tc.metrics), 0, nil, 0)
+
+			if got.KVCache == nil {
+				t.Fatalf("KVCache nil — kv_cache_usage/prefix metrics not mapped")
+			}
+			// 0.5 fraction → 50 percent.
+			if got.KVCache.GPUUsagePct == nil || math.Abs(*got.KVCache.GPUUsagePct-50) > 1e-6 {
+				t.Errorf("GPUUsagePct = %v, want 50", got.KVCache.GPUUsagePct)
+			}
+			// hits/queries = 80/100 = 0.8 (legacy gauge is 0.8 directly).
+			if got.KVCache.PrefixCacheHitRate == nil || math.Abs(*got.KVCache.PrefixCacheHitRate-0.8) > 1e-6 {
+				t.Errorf("PrefixCacheHitRate = %v, want 0.8", got.KVCache.PrefixCacheHitRate)
+			}
+
+			if got.Latency == nil {
+				t.Fatalf("Latency nil — tpot histogram not mapped")
+			}
+			// p50 bucket [0.01..0.02] → 0.02s → 20ms; p99 → 0.1s → 100ms.
+			if got.Latency.TPOTp50 == nil || math.Abs(*got.Latency.TPOTp50-20) > 1e-6 {
+				t.Errorf("TPOTp50 = %v, want 20ms", got.Latency.TPOTp50)
+			}
+			if got.Latency.TPOTp99 == nil || math.Abs(*got.Latency.TPOTp99-100) > 1e-6 {
+				t.Errorf("TPOTp99 = %v, want 100ms", got.Latency.TPOTp99)
+			}
+		})
+	}
+}
+
 func TestParseLabelSet_Quoted(t *testing.T) {
 	got := parseLabelSet(`a="1",b="two",c="three"`)
 	if len(got) != 3 {

--- a/internal/platforms/vllm/vllm.go
+++ b/internal/platforms/vllm/vllm.go
@@ -242,13 +242,24 @@ func buildModel(m vllmModel, prom *promSnapshot, ts int64, prev *promSnapshot, i
 		out.Queue = q
 	}
 	kv := &platforms.KVCache{}
-	if v, ok := prom.gauge("vllm:gpu_cache_usage_perc", label); ok {
+	// vLLM ≥0.6 renamed gpu_cache_usage_perc → kv_cache_usage_perc (fraction
+	// 0-1). Try the new name first, fall back to the legacy gauge.
+	if v, ok := prom.gauge("vllm:kv_cache_usage_perc", label); ok {
+		kv.GPUUsagePct = platforms.Float64Ptr(v * 100)
+	} else if v, ok := prom.gauge("vllm:gpu_cache_usage_perc", label); ok {
 		kv.GPUUsagePct = platforms.Float64Ptr(v * 100)
 	}
 	if v, ok := prom.gauge("vllm:cpu_cache_usage_perc", label); ok {
 		kv.CPUUsagePct = platforms.Float64Ptr(v * 100)
 	}
-	if v, ok := prom.gauge("vllm:gpu_prefix_cache_hit_rate", label); ok {
+	// vLLM ≥0.6 dropped the gpu_prefix_cache_hit_rate gauge and exposes
+	// prefix_cache_hits_total / prefix_cache_queries_total counters instead.
+	// Lifetime hit-rate = hits/queries; fall back to the legacy gauge.
+	if hits, ok := prom.counter("vllm:prefix_cache_hits_total", label); ok {
+		if q, ok2 := prom.counter("vllm:prefix_cache_queries_total", label); ok2 && q > 0 {
+			kv.PrefixCacheHitRate = platforms.Float64Ptr(hits / q)
+		}
+	} else if v, ok := prom.gauge("vllm:gpu_prefix_cache_hit_rate", label); ok {
 		kv.PrefixCacheHitRate = platforms.Float64Ptr(v)
 	}
 	if kv.GPUUsagePct != nil || kv.CPUUsagePct != nil || kv.PrefixCacheHitRate != nil {
@@ -262,10 +273,18 @@ func buildModel(m vllmModel, prom *promSnapshot, ts int64, prev *promSnapshot, i
 	if p99, ok := prom.histogramQuantile("vllm:time_to_first_token_seconds", label, 0.99); ok {
 		lat.TTFTp99 = platforms.Float64Ptr(p99 * 1000)
 	}
-	if p50, ok := prom.histogramQuantile("vllm:time_per_output_token_seconds", label, 0.5); ok {
+	// vLLM ≥0.6 renamed time_per_output_token_seconds →
+	// request_time_per_output_token_seconds. Try the new name, fall back.
+	tpot := func(q float64) (float64, bool) {
+		if v, ok := prom.histogramQuantile("vllm:request_time_per_output_token_seconds", label, q); ok {
+			return v, true
+		}
+		return prom.histogramQuantile("vllm:time_per_output_token_seconds", label, q)
+	}
+	if p50, ok := tpot(0.5); ok {
 		lat.TPOTp50 = platforms.Float64Ptr(p50 * 1000)
 	}
-	if p99, ok := prom.histogramQuantile("vllm:time_per_output_token_seconds", label, 0.99); ok {
+	if p99, ok := tpot(0.99); ok {
 		lat.TPOTp99 = platforms.Float64Ptr(p99 * 1000)
 	}
 	if p50, ok := prom.histogramQuantile("vllm:e2e_request_latency_seconds", label, 0.5); ok {


### PR DESCRIPTION
vLLM ≥0.6 renamed three series the agent scrapes in `internal/platforms/vllm/vllm.go::buildModel`, so on the current GB10 fleet the agent emits `latency_ms`(ttft/e2e) + `throughput` + `queue` + `counters` but **`kv_cache` and `tpot` come back empty**. Found while building the case-manager Eval Suite (the Compute tab needs these).

| was scraped (absent now) | vLLM ≥0.6 exposes |
|---|---|
| `vllm:gpu_cache_usage_perc` | `vllm:kv_cache_usage_perc` |
| `vllm:gpu_prefix_cache_hit_rate` (gauge) | `vllm:prefix_cache_hits_total` / `vllm:prefix_cache_queries_total` (counters → rate) |
| `vllm:time_per_output_token_seconds` | `vllm:request_time_per_output_token_seconds` |

All remapped **with backward-compat fallback** to the legacy names (older vLLM still works). Names confirmed present on live `:8100/metrics`. `go build ./... && go test ./...` green.

**Deploy:** requires rebuild + fleet redeploy of the agent for live nodes to start emitting `kv_cache`/`tpot`.

Follow-on (separate, larger — eval spec §9): expose `prefix_cache_hits_total`/`queries_total` + prefill histograms as raw counts on the structs for windowed-rate eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)