### PR TITLE
ci: pin Go toolchain to 1.25.11 (clears govulncheck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: true
       - name: vet
         run: go vet ./...

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: true
 
       - name: initialise codeql

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: true
       - name: build
         env:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: true
       - name: install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.25'
+          go-version: '1.25.11'
           cache: true
       - name: run gosec
         # Pinned by version tag; the action's image carries gosec itself.


### PR DESCRIPTION
## Why

`govulncheck` has been failing on `main` and on PR #16 with two **stdlib** advisories — unrelated to any repo code:

| Advisory | Package | Fixed in |
|---|---|---|
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | go1.25.11 |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | go1.25.11 |

The workflows pinned a floating `go-version: '1.25'`, which `setup-go` resolved to a **cached 1.25.10** on the runner — one patch short of the fix.

## What

Pin the exact patched **`1.25.11`** across all five `setup-go` steps (ci / release / security ×2 / codeql). `go1.25.11` is published on go.dev. Deterministic toolchain → both advisories clear.

`go.mod` stays at `go 1.22` — that's the intentional language baseline (CLAUDE.md: "Go 1.22+"); this PR only moves the build/scan toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)