### PR TITLE
feat(vllm): eval telemetry — prefix-cache counts, prefill/decode percentiles, cached tokens, failed requests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,14 @@ vLLM metric names that ≥0.6 renamed (`kv_cache_usage_perc`,
 `request_time_per_output_token_seconds`) with backward-compat
 fallback to the legacy names, so `kv_cache` and `tpot` populate
 again on current GB10 nodes. No wire-contract or config change.
+v0.2.13 adds eval telemetry (additive, vLLM ≥0.6 only — nil
+otherwise): raw prefix-cache hit/query counts behind the rate,
+PREFILL/DECODE phase-time percentiles (`latency_ms.prefill_*` /
+`decode_*`), `counters.prompt_tokens_cached_total`, and wires the
+declared-but-never-set `requests_failed_total` (finished_reason
+abort+error) — also fixing `requests_success_total` to sum across
+all finished_reason series instead of first-match (which silently
+reported only the `stop` series).
 [spec/SPEC.md](spec/SPEC.md) is the authoritative wire contract (any
 change there is a cross-repo break). [spec/V0_2_0_PLAN.md](spec/V0_2_0_PLAN.md)
 records the v0.2.0 design; [PLAN.md](PLAN.md) captures the original v0.1.0

--- a/docs/api/health.md
+++ b/docs/api/health.md
@@ -157,9 +157,13 @@ fields they already know about.
           "loaded": true,
           "context_window": 32768,
           "queue": {"running": 2, "waiting": 0},
-          "kv_cache": {"gpu_usage_pct": 74.3, "prefix_cache_hit_rate": 0.61},
-          "latency_ms": {"ttft_p50": 142, "ttft_p99": 480},
-          "counters": {"requests_success_total": 18472, "prompt_tokens_total": 92481723}
+          "kv_cache": {"gpu_usage_pct": 74.3, "prefix_cache_hit_rate": 0.61,
+                       "prefix_cache_hits_total": 56413852, "prefix_cache_queries_total": 92481723},
+          "latency_ms": {"ttft_p50": 142, "ttft_p99": 480,
+                         "prefill_p50": 920, "prefill_p99": 4100,
+                         "decode_p50": 6400, "decode_p99": 31000},
+          "counters": {"requests_success_total": 18472, "requests_failed_total": 3,
+                       "prompt_tokens_total": 92481723, "prompt_tokens_cached_total": 56413852}
         }
       ]
     }

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -42,13 +42,25 @@ rt_node_model_queue_running{platform="vllm",model="qwen3-vl:32b"}     <int>
 rt_node_model_queue_waiting{platform="vllm",model="qwen3-vl:32b"}     <int>
 rt_node_model_kv_cache_gpu_usage_pct{...}                             <0..100>
 rt_node_model_kv_cache_prefix_hit_rate{...}                           <0..1>
+rt_node_model_kv_cache_prefix_hits_total{...}                         <counter>   # v0.2.13, vLLM ≥0.6 only
+rt_node_model_kv_cache_prefix_queries_total{...}                      <counter>   # v0.2.13, vLLM ≥0.6 only
 rt_node_model_ttft_seconds{...,quantile="0.5"}                        <float>
 rt_node_model_ttft_seconds{...,quantile="0.99"}                       <float>
 rt_node_model_tpot_seconds{...,quantile="0.5"}                        <float>
+rt_node_model_prefill_seconds{...,quantile="0.5"}                     <float>     # v0.2.13: PREFILL phase time
+rt_node_model_prefill_seconds{...,quantile="0.99"}                    <float>
+rt_node_model_decode_seconds{...,quantile="0.5"}                      <float>     # v0.2.13: DECODE phase time
+rt_node_model_decode_seconds{...,quantile="0.99"}                     <float>
 rt_node_model_requests_success_total{...}                             <counter>
+rt_node_model_requests_failed_total{...}                              <counter>   # v0.2.13: abort + error
 rt_node_model_prompt_tokens_total{...}                                <counter>
+rt_node_model_prompt_tokens_cached_total{...}                         <counter>   # v0.2.13: cached prefill tokens
 rt_node_model_generation_tokens_total{...}                            <counter>
 ```
+
+Windowed prefix-cache hit rate (preferable to the lifetime
+`prefix_hit_rate` ratio):
+`rate(rt_node_model_kv_cache_prefix_hits_total[5m]) / rate(rt_node_model_kv_cache_prefix_queries_total[5m])`.
 
 ### Allocators
 

--- a/docs/platforms/vllm.md
+++ b/docs/platforms/vllm.md
@@ -42,6 +42,39 @@ populate `kv_cache` and `tpot`.
 If you need other quantiles, scrape `/metrics` directly and compute in
 PromQL — the agent only surfaces p50/p99 to keep `/health` payload small.
 
+## Eval telemetry (v0.2.13)
+
+For serving-efficiency evaluation the agent additionally surfaces, per
+model (all additive, nil when the underlying series is absent — i.e. on
+pre-0.6 vLLM):
+
+- `kv_cache.prefix_cache_hits_total` / `prefix_cache_queries_total` — the
+  raw token counts behind `prefix_cache_hit_rate`, so consumers can compute
+  *windowed* hit rates across their own scrape interval instead of the
+  lifetime ratio (which washes out behavior changes).
+- `latency_ms.prefill_p50/p99` and `decode_p50/p99` — per-request
+  PREFILL / DECODE phase-time histograms
+  (`vllm:request_prefill_time_seconds`, `vllm:request_decode_time_seconds`).
+  Note these are request-phase durations, not token-level timings; TTFT
+  also includes queue wait, these don't.
+- `counters.prompt_tokens_cached_total` — cached prompt tokens (local +
+  external), the per-model aggregate of the per-request `cached_tokens`.
+- `counters.requests_failed_total` — now wired (was declared but never
+  assigned): finished_reason `abort` + `error`. In the same change
+  `requests_success_total` was fixed to sum across **all** finished_reason
+  series minus failures — previously a first-match read reported only the
+  first series (in practice `stop`), undercounting `length`/`repetition`
+  completions.
+
+vLLM does not expose a prefill-tokens counter separate from
+`prompt_tokens_total` ("Number of prefill tokens processed" on ≥0.6), so
+there is deliberately no `prefill_tokens_total` / `prefill_tokens_per_s` —
+use `prompt_tokens_total` / `throughput.prompt_tokens_per_s`.
+
+Per-*request* granularity (per-request cached_tokens, request logs) is out
+of the agent's lane — read vLLM `/metrics` or request logs directly for
+that; the agent provides node-level rollups.
+
 ## Throughput rates
 
 `throughput.prompt_tokens_per_s` and `throughput.generation_tokens_per_s`

--- a/internal/platforms/platform.go
+++ b/internal/platforms/platform.go
@@ -100,20 +100,32 @@ type Queue struct {
 }
 
 // KVCache reports vLLM's KV cache utilization and prefix-cache hit rate.
+// The raw hit/query token counts (v0.2.13) sit behind the rate so consumers
+// can compute windowed rates over their own scrape interval instead of
+// being stuck with the lifetime ratio.
 type KVCache struct {
-	GPUUsagePct        *float64 `json:"gpu_usage_pct,omitempty"`
-	CPUUsagePct        *float64 `json:"cpu_usage_pct,omitempty"`
-	PrefixCacheHitRate *float64 `json:"prefix_cache_hit_rate,omitempty"`
+	GPUUsagePct             *float64 `json:"gpu_usage_pct,omitempty"`
+	CPUUsagePct             *float64 `json:"cpu_usage_pct,omitempty"`
+	PrefixCacheHitRate      *float64 `json:"prefix_cache_hit_rate,omitempty"`
+	PrefixCacheHitsTotal    *uint64  `json:"prefix_cache_hits_total,omitempty"`
+	PrefixCacheQueriesTotal *uint64  `json:"prefix_cache_queries_total,omitempty"`
 }
 
-// Latency reports request-latency percentiles in milliseconds.
+// Latency reports request-latency percentiles in milliseconds. Prefill/decode
+// (v0.2.13) come from the per-request phase-time histograms — prefill_p50 is
+// "half of requests spent ≤ this long in the PREFILL phase", not a
+// token-level number.
 type Latency struct {
-	TTFTp50 *float64 `json:"ttft_p50,omitempty"`
-	TTFTp99 *float64 `json:"ttft_p99,omitempty"`
-	TPOTp50 *float64 `json:"tpot_p50,omitempty"`
-	TPOTp99 *float64 `json:"tpot_p99,omitempty"`
-	E2Ep50  *float64 `json:"e2e_p50,omitempty"`
-	E2Ep99  *float64 `json:"e2e_p99,omitempty"`
+	TTFTp50    *float64 `json:"ttft_p50,omitempty"`
+	TTFTp99    *float64 `json:"ttft_p99,omitempty"`
+	TPOTp50    *float64 `json:"tpot_p50,omitempty"`
+	TPOTp99    *float64 `json:"tpot_p99,omitempty"`
+	E2Ep50     *float64 `json:"e2e_p50,omitempty"`
+	E2Ep99     *float64 `json:"e2e_p99,omitempty"`
+	PrefillP50 *float64 `json:"prefill_p50,omitempty"`
+	PrefillP99 *float64 `json:"prefill_p99,omitempty"`
+	DecodeP50  *float64 `json:"decode_p50,omitempty"`
+	DecodeP99  *float64 `json:"decode_p99,omitempty"`
 }
 
 // Throughput reports tokens-per-second rates.
@@ -124,11 +136,20 @@ type Throughput struct {
 }
 
 // Counters are cumulative since the platform started. Use rate() over them.
+//
+// requests_success_total counts requests that produced output (vLLM
+// finished_reason stop/length/repetition); requests_failed_total counts
+// abnormal terminations (abort/error). On vLLM ≥0.6 prompt_tokens_total IS
+// the prefill token count ("Number of prefill tokens processed"), and
+// prompt_tokens_cached_total (v0.2.13) is how many of those were served
+// from cache (local + external) — the per-model aggregate of the
+// OpenAI-API `cached_tokens` field.
 type Counters struct {
-	RequestsSuccessTotal  *uint64 `json:"requests_success_total,omitempty"`
-	RequestsFailedTotal   *uint64 `json:"requests_failed_total,omitempty"`
-	PromptTokensTotal     *uint64 `json:"prompt_tokens_total,omitempty"`
-	GenerationTokensTotal *uint64 `json:"generation_tokens_total,omitempty"`
+	RequestsSuccessTotal    *uint64 `json:"requests_success_total,omitempty"`
+	RequestsFailedTotal     *uint64 `json:"requests_failed_total,omitempty"`
+	PromptTokensTotal       *uint64 `json:"prompt_tokens_total,omitempty"`
+	PromptTokensCachedTotal *uint64 `json:"prompt_tokens_cached_total,omitempty"`
+	GenerationTokensTotal   *uint64 `json:"generation_tokens_total,omitempty"`
 }
 
 // Helper constructors so call sites can write IntPtr(n) instead of taking

--- a/internal/platforms/vllm/promparse.go
+++ b/internal/platforms/vllm/promparse.go
@@ -290,7 +290,9 @@ func (s *promSnapshot) gauge(name string, labels map[string]string) (float64, bo
 	return 0, false
 }
 
-// counter returns the cumulative value of the named counter.
+// counter returns the cumulative value of the named counter. First match
+// only — use counterSum for metrics that fan out over an extra label
+// (e.g. vllm:request_success_total has one series per finished_reason).
 func (s *promSnapshot) counter(name string, labels map[string]string) (float64, bool) {
 	for _, ls := range s.counters[name] {
 		if ls.labels.matches(labels) {
@@ -298,6 +300,20 @@ func (s *promSnapshot) counter(name string, labels map[string]string) (float64, 
 		}
 	}
 	return 0, false
+}
+
+// counterSum sums every series of the named counter whose labels contain
+// all of the given labels. ok=false when no series matched at all.
+func (s *promSnapshot) counterSum(name string, labels map[string]string) (float64, bool) {
+	var sum float64
+	found := false
+	for _, ls := range s.counters[name] {
+		if ls.labels.matches(labels) {
+			sum += ls.value
+			found = true
+		}
+	}
+	return sum, found
 }
 
 // histogramQuantile returns the value at the given quantile (0..1) using

--- a/internal/platforms/vllm/promparse_test.go
+++ b/internal/platforms/vllm/promparse_test.go
@@ -168,6 +168,133 @@ func TestBuildModel_MetricRenames(t *testing.T) {
 	}
 }
 
+// Eval-telemetry series (v0.2.13): prefill/decode phase histograms, cached
+// prompt tokens, and request_success_total fanned out over finished_reason
+// (the live ≥0.6 shape — engine label included to mirror real exposition).
+const sampleEvalTelemetry = `# HELP vllm:prefix_cache_hits_total Prefix cache hits.
+# TYPE vllm:prefix_cache_hits_total counter
+vllm:prefix_cache_hits_total{engine="0",model_name="m"} 80
+# HELP vllm:prefix_cache_queries_total Prefix cache queries.
+# TYPE vllm:prefix_cache_queries_total counter
+vllm:prefix_cache_queries_total{engine="0",model_name="m"} 100
+# HELP vllm:prompt_tokens_total Number of prefill tokens processed.
+# TYPE vllm:prompt_tokens_total counter
+vllm:prompt_tokens_total{engine="0",model_name="m"} 100
+# HELP vllm:prompt_tokens_cached_total Number of cached prompt tokens.
+# TYPE vllm:prompt_tokens_cached_total counter
+vllm:prompt_tokens_cached_total{engine="0",model_name="m"} 80
+# HELP vllm:request_success_total Count of finished requests.
+# TYPE vllm:request_success_total counter
+vllm:request_success_total{engine="0",finished_reason="stop",model_name="m"} 200
+vllm:request_success_total{engine="0",finished_reason="length",model_name="m"} 30
+vllm:request_success_total{engine="0",finished_reason="repetition",model_name="m"} 5
+vllm:request_success_total{engine="0",finished_reason="abort",model_name="m"} 3
+vllm:request_success_total{engine="0",finished_reason="error",model_name="m"} 2
+# HELP vllm:request_prefill_time_seconds Histogram of PREFILL phase time.
+# TYPE vllm:request_prefill_time_seconds histogram
+vllm:request_prefill_time_seconds_bucket{engine="0",model_name="m",le="0.5"} 0
+vllm:request_prefill_time_seconds_bucket{engine="0",model_name="m",le="1.0"} 50
+vllm:request_prefill_time_seconds_bucket{engine="0",model_name="m",le="2.0"} 99
+vllm:request_prefill_time_seconds_bucket{engine="0",model_name="m",le="+Inf"} 100
+vllm:request_prefill_time_seconds_sum{engine="0",model_name="m"} 90
+vllm:request_prefill_time_seconds_count{engine="0",model_name="m"} 100
+# HELP vllm:request_decode_time_seconds Histogram of DECODE phase time.
+# TYPE vllm:request_decode_time_seconds histogram
+vllm:request_decode_time_seconds_bucket{engine="0",model_name="m",le="5.0"} 0
+vllm:request_decode_time_seconds_bucket{engine="0",model_name="m",le="10.0"} 50
+vllm:request_decode_time_seconds_bucket{engine="0",model_name="m",le="20.0"} 99
+vllm:request_decode_time_seconds_bucket{engine="0",model_name="m",le="+Inf"} 100
+vllm:request_decode_time_seconds_sum{engine="0",model_name="m"} 1000
+vllm:request_decode_time_seconds_count{engine="0",model_name="m"} 100
+`
+
+func TestCounterSum_FinishedReasonFanout(t *testing.T) {
+	s := parsePrometheus(sampleEvalTelemetry)
+	lbl := map[string]string{"model_name": "m"}
+
+	// Sum across all finished_reason series: 200+30+5+3+2.
+	if v, ok := s.counterSum("vllm:request_success_total", lbl); !ok || v != 240 {
+		t.Errorf("counterSum all = %v, %v; want 240", v, ok)
+	}
+	// Narrowed to one reason.
+	abort := map[string]string{"model_name": "m", "finished_reason": "abort"}
+	if v, ok := s.counterSum("vllm:request_success_total", abort); !ok || v != 3 {
+		t.Errorf("counterSum abort = %v, %v; want 3", v, ok)
+	}
+	if _, ok := s.counterSum("vllm:request_success_total", map[string]string{"model_name": "absent"}); ok {
+		t.Errorf("expected ok=false for absent model")
+	}
+}
+
+func TestBuildModel_EvalTelemetry(t *testing.T) {
+	m := vllmModel{ID: "m"}
+	got := buildModel(m, parsePrometheus(sampleEvalTelemetry), 0, nil, 0)
+
+	if got.KVCache == nil {
+		t.Fatalf("KVCache nil")
+	}
+	if got.KVCache.PrefixCacheHitsTotal == nil || *got.KVCache.PrefixCacheHitsTotal != 80 {
+		t.Errorf("PrefixCacheHitsTotal = %v, want 80", got.KVCache.PrefixCacheHitsTotal)
+	}
+	if got.KVCache.PrefixCacheQueriesTotal == nil || *got.KVCache.PrefixCacheQueriesTotal != 100 {
+		t.Errorf("PrefixCacheQueriesTotal = %v, want 100", got.KVCache.PrefixCacheQueriesTotal)
+	}
+	if got.KVCache.PrefixCacheHitRate == nil || math.Abs(*got.KVCache.PrefixCacheHitRate-0.8) > 1e-9 {
+		t.Errorf("PrefixCacheHitRate = %v, want 0.8", got.KVCache.PrefixCacheHitRate)
+	}
+
+	if got.Latency == nil {
+		t.Fatalf("Latency nil — prefill/decode histograms not mapped")
+	}
+	// prefill p50: bucket [0.5..1.0], target 50 of 100 → 1.0s → 1000ms.
+	if got.Latency.PrefillP50 == nil || math.Abs(*got.Latency.PrefillP50-1000) > 1e-6 {
+		t.Errorf("PrefillP50 = %v, want 1000ms", got.Latency.PrefillP50)
+	}
+	// prefill p99: target 99 at end of bucket [1.0..2.0] → 2000ms.
+	if got.Latency.PrefillP99 == nil || math.Abs(*got.Latency.PrefillP99-2000) > 1e-6 {
+		t.Errorf("PrefillP99 = %v, want 2000ms", got.Latency.PrefillP99)
+	}
+	if got.Latency.DecodeP50 == nil || math.Abs(*got.Latency.DecodeP50-10000) > 1e-6 {
+		t.Errorf("DecodeP50 = %v, want 10000ms", got.Latency.DecodeP50)
+	}
+
+	if got.Counters == nil {
+		t.Fatalf("Counters nil")
+	}
+	// success = 240 total - (3 abort + 2 error) = 235; failed = 5. The old
+	// first-match read would have reported success=200 (the stop series only).
+	if got.Counters.RequestsSuccessTotal == nil || *got.Counters.RequestsSuccessTotal != 235 {
+		t.Errorf("RequestsSuccessTotal = %v, want 235", got.Counters.RequestsSuccessTotal)
+	}
+	if got.Counters.RequestsFailedTotal == nil || *got.Counters.RequestsFailedTotal != 5 {
+		t.Errorf("RequestsFailedTotal = %v, want 5", got.Counters.RequestsFailedTotal)
+	}
+	if got.Counters.PromptTokensCachedTotal == nil || *got.Counters.PromptTokensCachedTotal != 80 {
+		t.Errorf("PromptTokensCachedTotal = %v, want 80", got.Counters.PromptTokensCachedTotal)
+	}
+}
+
+// Legacy exposition (no prefill/decode histograms, no finished_reason
+// fan-out beyond what old builds emit) must keep producing the old fields
+// and leave the new ones nil — additive contract.
+func TestBuildModel_EvalTelemetry_AbsentOnLegacy(t *testing.T) {
+	m := vllmModel{ID: "qwen3-vl:32b"}
+	got := buildModel(m, parsePrometheus(sampleLegacy), 0, nil, 0)
+
+	if got.KVCache == nil {
+		t.Fatalf("KVCache nil on legacy")
+	}
+	if got.KVCache.PrefixCacheHitsTotal != nil || got.KVCache.PrefixCacheQueriesTotal != nil {
+		t.Errorf("prefix counts should be nil on legacy exposition")
+	}
+	if got.Latency == nil {
+		t.Fatalf("Latency nil on legacy")
+	}
+	if got.Latency.PrefillP50 != nil || got.Latency.DecodeP50 != nil {
+		t.Errorf("prefill/decode should be nil on legacy exposition")
+	}
+}
+
 func TestParseLabelSet_Quoted(t *testing.T) {
 	got := parseLabelSet(`a="1",b="two",c="three"`)
 	if len(got) != 3 {

--- a/internal/platforms/vllm/vllm.go
+++ b/internal/platforms/vllm/vllm.go
@@ -254,15 +254,22 @@ func buildModel(m vllmModel, prom *promSnapshot, ts int64, prev *promSnapshot, i
 	}
 	// vLLM ≥0.6 dropped the gpu_prefix_cache_hit_rate gauge and exposes
 	// prefix_cache_hits_total / prefix_cache_queries_total counters instead.
-	// Lifetime hit-rate = hits/queries; fall back to the legacy gauge.
+	// Lifetime hit-rate = hits/queries; fall back to the legacy gauge. The
+	// raw counts are surfaced too (v0.2.13) so consumers can compute
+	// windowed rates — the lifetime ratio washes out behavior changes.
 	if hits, ok := prom.counter("vllm:prefix_cache_hits_total", label); ok {
-		if q, ok2 := prom.counter("vllm:prefix_cache_queries_total", label); ok2 && q > 0 {
-			kv.PrefixCacheHitRate = platforms.Float64Ptr(hits / q)
+		kv.PrefixCacheHitsTotal = platforms.Uint64Ptr(uint64(hits))
+		if q, ok2 := prom.counter("vllm:prefix_cache_queries_total", label); ok2 {
+			kv.PrefixCacheQueriesTotal = platforms.Uint64Ptr(uint64(q))
+			if q > 0 {
+				kv.PrefixCacheHitRate = platforms.Float64Ptr(hits / q)
+			}
 		}
 	} else if v, ok := prom.gauge("vllm:gpu_prefix_cache_hit_rate", label); ok {
 		kv.PrefixCacheHitRate = platforms.Float64Ptr(v)
 	}
-	if kv.GPUUsagePct != nil || kv.CPUUsagePct != nil || kv.PrefixCacheHitRate != nil {
+	if kv.GPUUsagePct != nil || kv.CPUUsagePct != nil || kv.PrefixCacheHitRate != nil ||
+		kv.PrefixCacheHitsTotal != nil {
 		out.KVCache = kv
 	}
 
@@ -293,16 +300,53 @@ func buildModel(m vllmModel, prom *promSnapshot, ts int64, prev *promSnapshot, i
 	if p99, ok := prom.histogramQuantile("vllm:e2e_request_latency_seconds", label, 0.99); ok {
 		lat.E2Ep99 = platforms.Float64Ptr(p99 * 1000)
 	}
-	if lat.TTFTp50 != nil || lat.TTFTp99 != nil || lat.TPOTp50 != nil || lat.E2Ep50 != nil {
+	// Per-request phase-time histograms (v0.2.13): time spent in the
+	// PREFILL / DECODE phases. Gives the prefill-vs-decode split that
+	// TTFT alone can't (TTFT includes queue wait).
+	if p50, ok := prom.histogramQuantile("vllm:request_prefill_time_seconds", label, 0.5); ok {
+		lat.PrefillP50 = platforms.Float64Ptr(p50 * 1000)
+	}
+	if p99, ok := prom.histogramQuantile("vllm:request_prefill_time_seconds", label, 0.99); ok {
+		lat.PrefillP99 = platforms.Float64Ptr(p99 * 1000)
+	}
+	if p50, ok := prom.histogramQuantile("vllm:request_decode_time_seconds", label, 0.5); ok {
+		lat.DecodeP50 = platforms.Float64Ptr(p50 * 1000)
+	}
+	if p99, ok := prom.histogramQuantile("vllm:request_decode_time_seconds", label, 0.99); ok {
+		lat.DecodeP99 = platforms.Float64Ptr(p99 * 1000)
+	}
+	if lat.TTFTp50 != nil || lat.TTFTp99 != nil || lat.TPOTp50 != nil || lat.E2Ep50 != nil ||
+		lat.PrefillP50 != nil || lat.DecodeP50 != nil {
 		out.Latency = lat
 	}
 
 	counters := &platforms.Counters{}
-	if v, ok := prom.counter("vllm:request_success_total", label); ok {
-		counters.RequestsSuccessTotal = platforms.Uint64Ptr(uint64(v))
+	// vllm:request_success_total fans out over finished_reason (stop, length,
+	// abort, error, repetition, …) — one series each. A first-match read
+	// silently reported only the first series (in practice "stop"), so sum
+	// across the label (v0.2.13): success = requests that produced output,
+	// failed = abnormal terminations (abort + error).
+	if total, ok := prom.counterSum("vllm:request_success_total", label); ok {
+		var failed float64
+		for _, reason := range []string{"abort", "error"} {
+			l := map[string]string{"finished_reason": reason}
+			for k, v := range label {
+				l[k] = v
+			}
+			if v, ok2 := prom.counterSum("vllm:request_success_total", l); ok2 {
+				failed += v
+			}
+		}
+		counters.RequestsSuccessTotal = platforms.Uint64Ptr(uint64(total - failed))
+		counters.RequestsFailedTotal = platforms.Uint64Ptr(uint64(failed))
 	}
 	if v, ok := prom.counter("vllm:prompt_tokens_total", label); ok {
 		counters.PromptTokensTotal = platforms.Uint64Ptr(uint64(v))
+	}
+	// Cached prompt tokens (local + external) — the per-model aggregate of
+	// the per-request `cached_tokens` field (v0.2.13).
+	if v, ok := prom.counter("vllm:prompt_tokens_cached_total", label); ok {
+		counters.PromptTokensCachedTotal = platforms.Uint64Ptr(uint64(v))
 	}
 	if v, ok := prom.counter("vllm:generation_tokens_total", label); ok {
 		counters.GenerationTokensTotal = platforms.Uint64Ptr(uint64(v))

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -175,6 +175,12 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 				if m.KVCache.PrefixCacheHitRate != nil {
 					fmt.Fprintf(w, "rt_node_model_kv_cache_prefix_hit_rate{platform=%q,model=%q} %f\n", name, m.Name, *m.KVCache.PrefixCacheHitRate)
 				}
+				if m.KVCache.PrefixCacheHitsTotal != nil {
+					fmt.Fprintf(w, "rt_node_model_kv_cache_prefix_hits_total{platform=%q,model=%q} %d\n", name, m.Name, *m.KVCache.PrefixCacheHitsTotal)
+				}
+				if m.KVCache.PrefixCacheQueriesTotal != nil {
+					fmt.Fprintf(w, "rt_node_model_kv_cache_prefix_queries_total{platform=%q,model=%q} %d\n", name, m.Name, *m.KVCache.PrefixCacheQueriesTotal)
+				}
 			}
 			if m.Latency != nil {
 				if m.Latency.TTFTp50 != nil {
@@ -186,13 +192,31 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 				if m.Latency.TPOTp50 != nil {
 					fmt.Fprintf(w, "rt_node_model_tpot_seconds{platform=%q,model=%q,quantile=\"0.5\"} %f\n", name, m.Name, *m.Latency.TPOTp50/1000.0)
 				}
+				if m.Latency.PrefillP50 != nil {
+					fmt.Fprintf(w, "rt_node_model_prefill_seconds{platform=%q,model=%q,quantile=\"0.5\"} %f\n", name, m.Name, *m.Latency.PrefillP50/1000.0)
+				}
+				if m.Latency.PrefillP99 != nil {
+					fmt.Fprintf(w, "rt_node_model_prefill_seconds{platform=%q,model=%q,quantile=\"0.99\"} %f\n", name, m.Name, *m.Latency.PrefillP99/1000.0)
+				}
+				if m.Latency.DecodeP50 != nil {
+					fmt.Fprintf(w, "rt_node_model_decode_seconds{platform=%q,model=%q,quantile=\"0.5\"} %f\n", name, m.Name, *m.Latency.DecodeP50/1000.0)
+				}
+				if m.Latency.DecodeP99 != nil {
+					fmt.Fprintf(w, "rt_node_model_decode_seconds{platform=%q,model=%q,quantile=\"0.99\"} %f\n", name, m.Name, *m.Latency.DecodeP99/1000.0)
+				}
 			}
 			if m.Counters != nil {
 				if m.Counters.RequestsSuccessTotal != nil {
 					fmt.Fprintf(w, "rt_node_model_requests_success_total{platform=%q,model=%q} %d\n", name, m.Name, *m.Counters.RequestsSuccessTotal)
 				}
+				if m.Counters.RequestsFailedTotal != nil {
+					fmt.Fprintf(w, "rt_node_model_requests_failed_total{platform=%q,model=%q} %d\n", name, m.Name, *m.Counters.RequestsFailedTotal)
+				}
 				if m.Counters.PromptTokensTotal != nil {
 					fmt.Fprintf(w, "rt_node_model_prompt_tokens_total{platform=%q,model=%q} %d\n", name, m.Name, *m.Counters.PromptTokensTotal)
+				}
+				if m.Counters.PromptTokensCachedTotal != nil {
+					fmt.Fprintf(w, "rt_node_model_prompt_tokens_cached_total{platform=%q,model=%q} %d\n", name, m.Name, *m.Counters.PromptTokensCachedTotal)
 				}
 				if m.Counters.GenerationTokensTotal != nil {
 					fmt.Fprintf(w, "rt_node_model_generation_tokens_total{platform=%q,model=%q} %d\n", name, m.Name, *m.Counters.GenerationTokensTotal)


### PR DESCRIPTION
The §9 eval-telemetry PR the case-manager Eval Suite P1 phase gates on (GATE P1-0). Follow-on to #16. All additive — fields are `nil`/omitted when the underlying series is absent (pre-0.6 vLLM), so the wire contract only grows.

## New `/health` fields (per vLLM model)

| field | source series | why |
|---|---|---|
| `kv_cache.prefix_cache_hits_total` / `prefix_cache_queries_total` | `vllm:prefix_cache_{hits,queries}_total` | raw counts behind the existing rate → consumers can compute **windowed** hit-rates; the lifetime ratio washes out behavior changes |
| `latency_ms.prefill_p50/p99`, `decode_p50/p99` | `vllm:request_{prefill,decode}_time_seconds` histograms | the prefill-vs-decode split TTFT can't give (TTFT includes queue wait) |
| `counters.prompt_tokens_cached_total` | `vllm:prompt_tokens_cached_total` | per-model aggregate of per-request `cached_tokens` |
| `counters.requests_failed_total` | `vllm:request_success_total{finished_reason=abort\|error}` | declared since v0.2.0, never assigned — now wired |

## Bug fix included

`vllm:request_success_total` fans out over `finished_reason` (one series each). The first-match `counter()` read silently reported only the first series — in practice **`stop`** — undercounting `length`/`repetition` completions. New `counterSum()` sums across the label; `requests_success_total` = total − failed. On the live node below: 278 (266 stop + 12 length) vs 266 under first-match.

## Deliberate deviations from the eval-spec draft

- No `prefill_tokens_total` / `throughput.prefill_tokens_per_s`: on vLLM ≥0.6 `prompt_tokens_total` **is** "Number of prefill tokens processed" — a second field would fabricate a distinction. Documented in `docs/platforms/vllm.md`.
- Per-request granularity stays out of the agent's lane (node-level rollups only), per the spec's own scoping.

## Verification

- `go build ./... && go test ./...` green; new tests cover the v0.2.13 sample, `counterSum` fan-out, and a legacy-exposition guard (new fields stay nil).
- Validated against a live GB10 `/metrics` dump (gpt-oss-120b): prefix counts 242720/980137 (rate 0.248 ✓ matches existing field), prefill p50 563ms / decode p50 6.9s, cached 242720, failed 0.
- `/metrics` exposition gains matching `rt_node_model_*` lines (prefix hits/queries, prefill/decode seconds, failed, cached) — docs updated with the windowed-hit-rate PromQL.

**Deploy:** tag v0.2.13 + fleet redeploy, then the case-manager GATE P1-0 check should pass (`kv_cache.prefix_cache_hits_total` non-null on GB10 nodes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)