### PR TITLE
feat(timesync): GET /time caller↔node handshake + configurable clock_offset_high + chrony fleet tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,15 @@ PREFILL/DECODE phase-time percentiles (`latency_ms.prefill_*` /
 declared-but-never-set `requests_failed_total` (finished_reason
 abort+error) — also fixing `requests_success_total` to sum across
 all finished_reason series instead of first-match (which silently
-reported only the `stop` series).
+reported only the `stop` series). v0.2.14 adds the `GET /time`
+endpoint — an NTP-style four-timestamp handshake so the backend can
+measure caller↔node clock offset (Offset B) to sub-ms, complementing
+the node↔reference offset (Offset A) from the existing
+`timesync.server` probe (now also folded into `/time`). The
+`clock_offset_high` threshold becomes configurable
+(`timesync.offset_degraded_ms`, default 100; `0` disables) for
+measure-only fleets whose clocks intentionally free-run. New
+capability flag `time_handshake_supported`; additive wire change.
 [spec/SPEC.md](spec/SPEC.md) is the authoritative wire contract (any
 change there is a cross-repo break). [spec/V0_2_0_PLAN.md](spec/V0_2_0_PLAN.md)
 records the v0.2.0 design; [PLAN.md](PLAN.md) captures the original v0.1.0

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ read [ARCHITECTURE.md](../ARCHITECTURE.md) first.
 ## API reference
 
 - [api/health.md](api/health.md) — `GET /health`, every field.
+- [api/time.md](api/time.md) — `GET /time`, the caller↔node clock-offset handshake (and the two-offset model).
 - [api/capabilities.md](api/capabilities.md) — `GET /capabilities`, used by the dispatcher for feature detection.
 - [api/version.md](api/version.md) — `GET /version`.
 - [api/metrics.md](api/metrics.md) — `GET /metrics`, Prometheus exposition.
@@ -22,6 +23,7 @@ read [ARCHITECTURE.md](../ARCHITECTURE.md) first.
 ## Topics
 
 - [degraded-reasons.md](degraded-reasons.md) — canonical reason list.
+- [timesync-fleet.md](timesync-fleet.md) — chrony fleet setup + the two clock offsets the agent measures.
 - [remote-actions.md](remote-actions.md) — security model for mutating endpoints.
 - [platforms/ollama.md](platforms/ollama.md) — Ollama probe.
 - [platforms/vllm.md](platforms/vllm.md) — vLLM probe + Prometheus scrape.

--- a/docs/api/capabilities.md
+++ b/docs/api/capabilities.md
@@ -18,6 +18,7 @@ rely on without parsing semver.
   "rdma_available": true,
   "training_mode_supported": true,
   "metrics_enabled": true,
+  "time_handshake_supported": true,
   "system_metrics_fields_supported": [
     "cpu.usage_pct", "cpu.usage_per_core_pct", "cpu.load_1m",
     "memory.unified", "memory.pressure", "memory.huge_pages_total",
@@ -34,6 +35,10 @@ rely on without parsing semver.
 - `training_mode_supported` is `true` on every OS — the state machine is
   cross-platform. The endpoint will still 503 if the host can't actually
   drain Ollama (e.g. no Ollama running).
+- `time_handshake_supported` is `true` from v0.2.14 on — the node serves
+  `GET /time` (the caller↔node NTP-style offset handshake). When `false`
+  (older agents), fall back to `time_sync.now_unix_ns` + the caller's own
+  RTT/2. See [time.md](time.md).
 - `services_allowlist` lists exactly what `POST /actions/service` will
   accept. Anything outside this list returns 403.
 - `system_metrics_fields_supported` is the canonical list of `/health`

--- a/docs/api/time.md
+++ b/docs/api/time.md
@@ -1,0 +1,80 @@
+# `GET /time`
+
+A minimal NTP-over-HTTP four-timestamp handshake. It lets the calling
+backend measure its clock offset to *this node* (**Offset B**) to sub-ms,
+independent of `/health` composition cost. No auth (LAN-open, same posture
+as `/health`).
+
+```
+GET /time?t1=<unix_ns>
+```
+
+`t1` is the caller's send time in Unix nanoseconds (optional — echoed as
+`0` when absent).
+
+```json
+{
+  "t1_unix_ns": 1749600000000000000,
+  "t2_unix_ns": 1749600000001234567,
+  "t3_unix_ns": 1749600000001240000,
+  "server": {
+    "host": "10.0.0.10",
+    "offset_ms": 1.23,
+    "rtt_ms": 0.4,
+    "stratum": 3,
+    "last_probe_age_s": 7,
+    "probe_interval_s": 60
+  }
+}
+```
+
+| field | meaning |
+|---|---|
+| `t1_unix_ns` | echoed caller send time (`0` if `?t1` absent/unparseable) |
+| `t2_unix_ns` | node **receive** time, stamped at handler entry |
+| `t3_unix_ns` | node **transmit** time, stamped just before the write |
+| `server` | the cached `timesync.server` probe (**Offset A**, node ↔ reference); omitted when `timesync.server` is empty |
+
+The agent does no probing or allocation between `t2` and `t3`, so the
+round-trip the caller measures is the network path, not agent work.
+
+## Computing Offset B (caller side)
+
+Record `t4` on receipt, then per RFC 5905 §8:
+
+```
+offset_ms = (((t2 - t1) + (t3 - t4)) / 2) / 1e6     # + => node ahead of caller
+rtt_ms    = ((t4 - t1) - (t3 - t2)) / 1e6
+```
+
+`offset_ms` is what you add to the caller's clock to match the node's. To
+translate a node-reported timestamp into the caller's frame, **subtract**
+`offset_ms`.
+
+## The two offsets
+
+- **Offset A — node ↔ reference.** `server.offset_ms` here (and
+  `/health.time_sync.server.offset_ms`): the node's clock vs. the
+  configured `timesync.server`. Sign **node − reference** (positive = node
+  ahead). Use for cross-node alignment — `node_i − node_j = A_i − A_j`.
+- **Offset B — caller ↔ node.** Computed by the caller from the handshake
+  above. Use to read a node's timestamps directly in the caller's frame.
+
+They are independent: A anchors every node to one shared reference; B
+anchors each node to *this* caller, which may run on a different reference
+(or none — e.g. an air-gapped fleet measuring offsets without disciplining
+clocks).
+
+## Feature detection
+
+Older agents (pre-0.2.14) don't serve `/time`. Check
+`capabilities.time_handshake_supported`; when false, fall back to
+`/health.time_sync.now_unix_ns` + the caller's own RTT/2 (coarser — bounded
+by the `/health` compose+write tail).
+
+## Notes
+
+- Method other than `GET` → `405`.
+- Air-gapped fleets must point `timesync.server` at an internal NTP box, or
+  the `server` block has no `offset_ms` (probe only logs timeouts). See
+  [timesync-fleet.md](../timesync-fleet.md) for standing one up with chrony.

--- a/docs/config.md
+++ b/docs/config.md
@@ -115,6 +115,26 @@ rdma:
 
 See [rdma.md](rdma.md). Linux-only; ignored on macOS/Windows.
 
+## `timesync`
+
+```yaml
+timesync:
+  server: time.cloudflare.com   # NTP server the agent probes (Offset A). "" disables the probe.
+  offset_degraded_ms: 100       # |offset_ms| that fires clock_offset_high. 0 disables (measure-only).
+```
+
+- `server` is the NTP host the agent queries every 60s; the result feeds
+  `time_sync.server.*` and `GET /time`. **Air-gapped fleets must set this
+  to an internal NTP server** — the `time.cloudflare.com` default is
+  unreachable offline, leaving the probe blind.
+- `offset_degraded_ms` is the `clock_offset_high` threshold. Set to `0`
+  (or negative) to disable the reason on measure-only fleets whose clocks
+  intentionally free-run.
+
+See [api/time.md](api/time.md) for the two-offset model and the
+caller↔node handshake. Works on every OS (NTP is UDP); the OS-sync-daemon
+fields (`source`/`skew_ms`) are Linux/macOS-only.
+
 ## Environment variables (override file)
 
 | Variable | Maps to |

--- a/docs/degraded-reasons.md
+++ b/docs/degraded-reasons.md
@@ -49,7 +49,7 @@ node). **soft** reasons stay in `reasons[]` but `degraded` may be false
 |---|---|
 | `disk_over_90pct` | Any monitored disk > 90% used. |
 | `clock_skew_high` | `abs(time_sync.skew_ms) > 100`. From the local OS sync daemon (chrony/timesyncd on Linux, sntp on darwin). Silent on Windows. |
-| `clock_offset_high` | `abs(time_sync.server.offset_ms) > 100`. From the agent's own NTP probe against `timesync.server` (defaults to `time.cloudflare.com`). Independent of `clock_skew_high` — both can fire simultaneously when the local sync daemon and the external reference disagree. Silent when `timesync.server` is empty or no probe has succeeded yet. |
+| `clock_offset_high` | `abs(time_sync.server.offset_ms) > timesync.offset_degraded_ms` (config, default `100`). From the agent's own NTP probe against `timesync.server` (defaults to `time.cloudflare.com`). Independent of `clock_skew_high` — both can fire simultaneously when the local sync daemon and the external reference disagree. Silent when `timesync.server` is empty, when no probe has succeeded yet, or when `offset_degraded_ms <= 0` (disabled — for measure-only fleets whose clocks intentionally free-run). |
 | `cpu_thermal_throttling` | `cpu.throttled == true`. Skipped when the metric is `null` (e.g. macOS without root). |
 | `gpu_thermal_throttling` | Any `gpu.throttle_reasons` contains `HW_THERMAL_SLOWDOWN` or `SW_THERMAL_SLOWDOWN`. |
 | `gpu_power_throttling` | Any `gpu.throttle_reasons` contains `HW_POWER_BRAKE_SLOWDOWN` or `SW_POWER_CAP`. |

--- a/docs/timesync-fleet.md
+++ b/docs/timesync-fleet.md
@@ -1,0 +1,79 @@
+# Fleet time sync (chrony) + how the agent measures it
+
+The agent **measures** clock offsets; it never disciplines the clock (it's
+read-only by design). To actually keep the fleet's clocks aligned you run a
+local NTP server and point every node at it. This page covers both: the
+chrony setup, and how the two agent offsets light up afterward.
+
+## Topology
+
+```
+            (WAN uplink: Starlink / internet)
+                        │
+                        ▼
+            ┌───────────────────────┐
+            │  local NTP server     │  chrony: disciplines from public NTP,
+            │  e.g. 10.0.0.10       │  serves the LAN, `local stratum 10`
+            └───────────┬───────────┘  fallback if the uplink drops
+                        │  LAN (NTP/UDP 123)
+        ┌───────────────┼───────────────┐
+        ▼               ▼               ▼
+     node A          node B          node C        chrony clients →
+   (rt-node-agent) (rt-node-agent) (rt-node-agent)  the local server only
+```
+
+One box is the **server** (the only one that needs the WAN uplink); every
+node is a **client** that needs nothing but the LAN.
+
+## Setup
+
+Run [`scripts/timesync/setup-timesync.sh`](../scripts/timesync/setup-timesync.sh)
+as root on each box (it installs chrony, writes the config, and starts it):
+
+```sh
+# on the NTP server box — pass the LAN CIDR allowed to query it:
+sudo ./scripts/timesync/setup-timesync.sh server 10.0.0.0/24
+
+# on every node — pass the NTP server's LAN IP:
+sudo ./scripts/timesync/setup-timesync.sh client 10.0.0.10
+```
+
+The server keeps serving at `stratum 10` even if the Starlink uplink drops,
+so the fleet stays internally consistent through an outage (it just drifts
+together from true UTC until the uplink returns).
+
+Verify on any box: `chronyc tracking` (offset from its source) and
+`chronyc -n sources` (who it's talking to).
+
+## How the agent reports it afterward
+
+With chrony running, the agent's existing `/health.time_sync` OS-sync fields
+populate on every box — `source: "chrony"`, `synced: true`, `skew_ms`,
+`stratum` — read straight from `chronyc tracking`.
+
+To also get the two cross-node offsets, point the agent's `timesync.server`
+at the **local NTP server** on each node ([config.md](config.md)):
+
+```yaml
+timesync:
+  server: 10.0.0.10        # the local NTP server (NOT the internet default)
+  offset_degraded_ms: 100  # clocks are disciplined now → keep the alarm on
+```
+
+Then:
+
+- **Offset A — node ↔ reference** comes from the agent's own probe against
+  that server: `/health.time_sync.server.offset_ms` (and in `GET /time`).
+  With chrony disciplining the node, this stays small; `clock_offset_high`
+  fires only on real drift.
+- **Offset B — caller ↔ node** is measured by the backend via
+  [`GET /time`](api/time.md) (the four-timestamp handshake) — independent of
+  whether the node's clock is disciplined.
+
+> Air-gapped note: if a node truly has no path to the NTP server, leave
+> `timesync.server` empty (probe off) or set `offset_degraded_ms: 0` to run
+> measure-only — the backend then compensates using Offset B from `GET /time`
+> rather than relying on disciplined clocks.
+
+See [api/time.md](api/time.md) for the offset formulas and sign conventions,
+and [degraded-reasons.md](degraded-reasons.md) for `clock_offset_high`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,8 +56,19 @@ type TimeSyncConfig struct {
 	// Server is the NTP hostname (with optional :port; 123 assumed) the
 	// agent queries on a 60s background loop. Empty disables the probe
 	// — /health.time_sync.server is then omitted entirely. Default:
-	// time.cloudflare.com (set in Defaults()).
+	// time.cloudflare.com (set in Defaults()). Air-gapped fleets must
+	// point this at an internal NTP server or the probe only logs
+	// timeouts and clock_offset_high goes blind.
 	Server string `yaml:"server"`
+
+	// OffsetDegradedMS is the |offset_ms| threshold (from the agent's NTP
+	// probe against Server) above which the soft degraded reason
+	// clock_offset_high fires. Zero or negative disables the reason —
+	// appropriate for measure-only fleets whose node clocks intentionally
+	// free-run (the offset is consumed/compensated by the backend rather
+	// than disciplined on the node), where a fixed threshold would just
+	// latch permanently. Default 100 (set in Defaults()).
+	OffsetDegradedMS float64 `yaml:"offset_degraded_ms"`
 }
 
 // PlatformsConfig wires per-platform detection.
@@ -137,7 +148,8 @@ func Defaults() Config {
 			ErrorsGrowingWindowS:    60,
 		},
 		TimeSync: TimeSyncConfig{
-			Server: "time.cloudflare.com",
+			Server:           "time.cloudflare.com",
+			OffsetDegradedMS: 100,
 		},
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -116,13 +116,22 @@ service_allocators:
 # compute cross-node offsets. When ` + "`timesync.server`" + ` is set (the default),
 # the agent additionally runs its own NTP query against that server every
 # 60s and surfaces local-vs-server offset under
-# /health.time_sync.server.{offset_ms,rtt_ms,stratum,error}. The new soft
-# degraded reason ` + "`clock_offset_high`" + ` fires when |offset_ms| > 100.
+# /health.time_sync.server.{offset_ms,rtt_ms,stratum,error} (this is
+# "Offset A" — node vs reference). GET /time exposes the same probe plus a
+# four-timestamp handshake for the caller to measure "Offset B" (caller vs
+# node) to sub-ms; see SPEC.md.
 #
-# Set to the empty string to disable the agent-driven probe entirely
-# (the wall-clock + OS-sync fields still populate). The default points at
-# Cloudflare's public anycast NTP service — accurate, NTS-capable, no
-# leap-second smearing.
+# Set 'server' to the empty string to disable the agent-driven probe
+# entirely (the wall-clock + OS-sync fields still populate). The default
+# points at Cloudflare's public anycast NTP service — AIR-GAPPED FLEETS
+# MUST change this to an internal NTP server, else the probe only logs
+# timeouts and Offset A / clock_offset_high go blind.
+#
+# offset_degraded_ms: |offset_ms| above which the soft degraded reason
+# clock_offset_high fires. Set to 0 to disable — appropriate for
+# measure-only fleets whose clocks intentionally free-run (the backend
+# compensates with the measured offset rather than disciplining the node).
 timesync:
   server: time.cloudflare.com
+  offset_degraded_ms: 100
 `

--- a/internal/health/clock_offset_test.go
+++ b/internal/health/clock_offset_test.go
@@ -22,9 +22,16 @@ func withServerOffset(now time.Time, v float64) Report {
 	return r
 }
 
+// offsetCfg builds a config carrying just the clock_offset_high threshold,
+// mirroring what Defaults() supplies in production (where the zero value
+// never reaches Evaluate).
+func offsetCfg(ms float64) config.Config {
+	return config.Config{TimeSync: config.TimeSyncConfig{OffsetDegradedMS: ms}}
+}
+
 func TestEvaluate_ClockOffsetHigh_PositiveFires(t *testing.T) {
 	now := time.Unix(1713820000, 0)
-	deg, reasons := Evaluate(withServerOffset(now, 250), config.Config{}, now)
+	deg, reasons := Evaluate(withServerOffset(now, 250), offsetCfg(100), now)
 	if deg {
 		t.Errorf("clock_offset_high is soft, must not set degraded=true")
 	}
@@ -35,7 +42,7 @@ func TestEvaluate_ClockOffsetHigh_PositiveFires(t *testing.T) {
 
 func TestEvaluate_ClockOffsetHigh_NegativeFires(t *testing.T) {
 	now := time.Unix(1713820000, 0)
-	_, reasons := Evaluate(withServerOffset(now, -500), config.Config{}, now)
+	_, reasons := Evaluate(withServerOffset(now, -500), offsetCfg(100), now)
 	if !contains(reasons, ReasonClockOffsetHigh) {
 		t.Errorf("offset_ms=-500 should fire clock_offset_high; got %v", reasons)
 	}
@@ -43,7 +50,7 @@ func TestEvaluate_ClockOffsetHigh_NegativeFires(t *testing.T) {
 
 func TestEvaluate_ClockOffsetHigh_BelowThresholdSilent(t *testing.T) {
 	now := time.Unix(1713820000, 0)
-	_, reasons := Evaluate(withServerOffset(now, 50), config.Config{}, now)
+	_, reasons := Evaluate(withServerOffset(now, 50), offsetCfg(100), now)
 	if contains(reasons, ReasonClockOffsetHigh) {
 		t.Errorf("offset_ms=50 should be below the 100ms threshold; got %v", reasons)
 	}
@@ -58,7 +65,7 @@ func TestEvaluate_ClockOffsetHigh_SilentWhenNoServerConfigured(t *testing.T) {
 	now := time.Unix(1713820000, 0)
 	r := cleanReport(now)
 	r.TimeSync = &timesync.Info{} // wall-clock-only Info, no Server
-	_, reasons := Evaluate(r, config.Config{}, now)
+	_, reasons := Evaluate(r, offsetCfg(100), now)
 	if contains(reasons, ReasonClockOffsetHigh) {
 		t.Errorf("clock_offset_high must be silent when Server is nil; got %v", reasons)
 	}
@@ -74,8 +81,30 @@ func TestEvaluate_ClockOffsetHigh_SilentBeforeFirstProbe(t *testing.T) {
 			Error: "timeout",
 		},
 	}
-	_, reasons := Evaluate(r, config.Config{}, now)
+	_, reasons := Evaluate(r, offsetCfg(100), now)
 	if contains(reasons, ReasonClockOffsetHigh) {
 		t.Errorf("clock_offset_high must be silent before first successful probe; got %v", reasons)
+	}
+}
+
+// Measure-only fleets disable the reason (offset_degraded_ms <= 0): even a
+// large offset must stay silent, because the clock is intentionally
+// free-running and the offset is compensated by the backend, not the node.
+func TestEvaluate_ClockOffsetHigh_DisabledWhenThresholdZero(t *testing.T) {
+	now := time.Unix(1713820000, 0)
+	_, reasons := Evaluate(withServerOffset(now, 5000), offsetCfg(0), now)
+	if contains(reasons, ReasonClockOffsetHigh) {
+		t.Errorf("offset_degraded_ms=0 must disable clock_offset_high; got %v", reasons)
+	}
+}
+
+// A custom threshold is honored on both sides of the boundary.
+func TestEvaluate_ClockOffsetHigh_CustomThreshold(t *testing.T) {
+	now := time.Unix(1713820000, 0)
+	if _, reasons := Evaluate(withServerOffset(now, 250), offsetCfg(300), now); contains(reasons, ReasonClockOffsetHigh) {
+		t.Errorf("offset 250 < threshold 300 must be silent; got %v", reasons)
+	}
+	if _, reasons := Evaluate(withServerOffset(now, 350), offsetCfg(300), now); !contains(reasons, ReasonClockOffsetHigh) {
+		t.Errorf("offset 350 > threshold 300 must fire; got %v", reasons)
 	}
 }

--- a/internal/health/degraded.go
+++ b/internal/health/degraded.go
@@ -156,7 +156,7 @@ func Evaluate(r Report, cfg config.Config, now time.Time) (bool, []string) {
 	if clockSkewHigh(r) {
 		reasons = append(reasons, ReasonClockSkewHigh)
 	}
-	if clockOffsetHigh(r) {
+	if clockOffsetHigh(r, cfg) {
 		reasons = append(reasons, ReasonClockOffsetHigh)
 	}
 	if r.CPU.Throttled != nil && *r.CPU.Throttled {
@@ -247,12 +247,19 @@ func clockSkewHigh(r Report) bool {
 }
 
 // clockOffsetHigh fires when the agent's own NTP probe against
-// timesync.server disagrees with the local clock by more than 100 ms.
+// timesync.server disagrees with the local clock by more than the
+// configured threshold (timesync.offset_degraded_ms, default 100 ms).
 // Independent of clockSkewHigh — the local OS sync daemon and the
 // agent-driven probe are two independent reference points and both
-// can fire. Silent when no server is configured or no successful probe
-// has completed yet (silence beats fabrication).
-func clockOffsetHigh(r Report) bool {
+// can fire. Silent when the threshold is <= 0 (disabled, e.g. measure-only
+// fleets that intentionally let clocks free-run), when no server is
+// configured, or when no successful probe has completed yet (silence
+// beats fabrication).
+func clockOffsetHigh(r Report, cfg config.Config) bool {
+	thresh := cfg.TimeSync.OffsetDegradedMS
+	if thresh <= 0 {
+		return false
+	}
 	if r.TimeSync == nil || r.TimeSync.Server == nil || r.TimeSync.Server.OffsetMS == nil {
 		return false
 	}
@@ -260,7 +267,7 @@ func clockOffsetHigh(r Report) bool {
 	if v < 0 {
 		v = -v
 	}
-	return v > 100
+	return v > thresh
 }
 
 // vllmRequiredDown fires when config says vllm is required but the platforms

--- a/internal/server/capabilities.go
+++ b/internal/server/capabilities.go
@@ -14,17 +14,22 @@ import (
 //
 // Read-only, no auth (LAN open) — same trust posture as /health.
 type Capabilities struct {
-	AgentVersion                  string   `json:"agent_version"`
-	ConfigVersion                 int      `json:"config_version"`
-	OS                            string   `json:"os"`
-	Arch                          string   `json:"arch"`
-	PlatformsSupported            []string `json:"platforms_supported"`
-	ActionsSupported              []string `json:"actions_supported"`
-	ServicesAllowlist             []string `json:"services_allowlist"`
-	RDMAAvailable                 bool     `json:"rdma_available"`
-	TrainingModeSupported         bool     `json:"training_mode_supported"`
-	MetricsEnabled                bool     `json:"metrics_enabled"`
-	SystemMetricsFieldsSupported  []string `json:"system_metrics_fields_supported"`
+	AgentVersion          string   `json:"agent_version"`
+	ConfigVersion         int      `json:"config_version"`
+	OS                    string   `json:"os"`
+	Arch                  string   `json:"arch"`
+	PlatformsSupported    []string `json:"platforms_supported"`
+	ActionsSupported      []string `json:"actions_supported"`
+	ServicesAllowlist     []string `json:"services_allowlist"`
+	RDMAAvailable         bool     `json:"rdma_available"`
+	TrainingModeSupported bool     `json:"training_mode_supported"`
+	MetricsEnabled        bool     `json:"metrics_enabled"`
+	// TimeHandshakeSupported advertises the GET /time NTP-style
+	// four-timestamp endpoint (v0.2.14). Backends key off this to use the
+	// precise caller↔node offset handshake; older nodes lack it and the
+	// backend falls back to time_sync.now_unix_ns + its own RTT/2.
+	TimeHandshakeSupported       bool     `json:"time_handshake_supported"`
+	SystemMetricsFieldsSupported []string `json:"system_metrics_fields_supported"`
 }
 
 func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
@@ -33,14 +38,15 @@ func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	c := Capabilities{
-		AgentVersion:       buildinfo.Version,
-		ConfigVersion:      config.SchemaVersion,
-		OS:                 runtime.GOOS,
-		Arch:               runtime.GOARCH,
-		PlatformsSupported: []string{"ollama", "vllm"},
-		ActionsSupported:   []string{"unload-model", "service", "training-mode"},
-		MetricsEnabled:     s.cfg.MetricsEnabled,
-		TrainingModeSupported: true,
+		AgentVersion:           buildinfo.Version,
+		ConfigVersion:          config.SchemaVersion,
+		OS:                     runtime.GOOS,
+		Arch:                   runtime.GOARCH,
+		PlatformsSupported:     []string{"ollama", "vllm"},
+		ActionsSupported:       []string{"unload-model", "service", "training-mode"},
+		MetricsEnabled:         s.cfg.MetricsEnabled,
+		TrainingModeSupported:  true,
+		TimeHandshakeSupported: true,
 	}
 	// RDMA presence is detected at probe time; the agent advertises support
 	// when the package's runtime check passes. On non-Linux we always

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/redtorchinc/node-agent/internal/buildinfo"
+	"github.com/redtorchinc/node-agent/internal/sysmetrics/timesync"
 )
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
@@ -38,6 +40,56 @@ func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
 		"git_sha":    buildinfo.GitSHA,
 		"build_time": buildinfo.BuildTime,
 	})
+}
+
+// timeResp is the GET /time wire shape — a minimal NTP-over-HTTP
+// four-timestamp handshake for the caller (the case-manager backend) to
+// compute its own clock offset to this node with sub-ms precision,
+// independent of /health composition cost.
+//
+// The caller passes its send time as ?t1=<unix_ns>. The agent stamps t2
+// the instant the handler runs (receive) and t3 immediately before the
+// write (transmit). The caller records t4 on receipt and computes, per
+// RFC 5905 §8:
+//
+//	offset_ms = (((t2-t1) + (t3-t4)) / 2) / 1e6   // + ⇒ node ahead of caller
+//	rtt_ms    = ((t4-t1) - (t3-t2)) / 1e6
+//
+// This is "Offset B" (caller ↔ node). The embedded Server block is
+// "Offset A" (node ↔ the configured internal reference clock), folded in
+// from the same cached probe that feeds /health.time_sync.server so the
+// backend gets both offsets from one cheap call.
+type timeResp struct {
+	T1UnixNS int64                `json:"t1_unix_ns"` // echoed caller send time (0 if ?t1 absent/unparseable)
+	T2UnixNS int64                `json:"t2_unix_ns"` // node receive time (handler entry)
+	T3UnixNS int64                `json:"t3_unix_ns"` // node transmit time (just before write)
+	Server   *timesync.ServerInfo `json:"server,omitempty"`
+}
+
+// handleTime serves the GET /time handshake. Open read endpoint (LAN
+// trust, same posture as /health). Deliberately does no probing or
+// allocation between the t2 and t3 stamps so the round-trip the caller
+// measures is dominated by the network path, not agent work.
+func (s *Server) handleTime(w http.ResponseWriter, r *http.Request) {
+	t2 := time.Now().UnixNano()
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var t1 int64
+	if q := r.URL.Query().Get("t1"); q != "" {
+		// Best-effort: a malformed t1 echoes 0 rather than erroring — the
+		// caller can detect the miss and retry, and t2/t3 are still useful.
+		t1, _ = strconv.ParseInt(q, 10, 64)
+	}
+	// Cheap RLock read of the cached probe (no network) — nil-safe when
+	// timesync.server is unset.
+	server := s.reporter.TimeServer.Snapshot()
+
+	w.Header().Set("Content-Type", "application/json")
+	resp := timeResp{T1UnixNS: t1, T2UnixNS: t2, Server: server}
+	resp.T3UnixNS = time.Now().UnixNano()
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 type unloadReq struct {

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/redtorchinc/node-agent/internal/config"
 	"github.com/redtorchinc/node-agent/internal/health"
@@ -18,6 +20,81 @@ func newTestServer(t *testing.T, cfg config.Config) *Server {
 		t.Fatalf("NewReporter: %v", err)
 	}
 	return New(cfg, r)
+}
+
+func TestTimeHandler_Handshake(t *testing.T) {
+	s := newTestServer(t, config.Defaults())
+	const t1 = int64(1700000000000000000)
+
+	before := time.Now().UnixNano()
+	req := httptest.NewRequest(http.MethodGet, "/time?t1="+strconv.FormatInt(t1, 10), nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	after := time.Now().UnixNano()
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d body=%s", w.Code, w.Body.String())
+	}
+	var resp timeResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.T1UnixNS != t1 {
+		t.Errorf("t1 not echoed: got %d want %d", resp.T1UnixNS, t1)
+	}
+	// t2 (receive) must precede or equal t3 (transmit), and both must fall
+	// inside the window the test observed the request — proves they're
+	// real per-request stamps, not a cached/zero value.
+	if resp.T2UnixNS > resp.T3UnixNS {
+		t.Errorf("t2 (%d) must be <= t3 (%d)", resp.T2UnixNS, resp.T3UnixNS)
+	}
+	if resp.T2UnixNS < before || resp.T3UnixNS > after {
+		t.Errorf("t2/t3 outside observed window [%d,%d]: t2=%d t3=%d", before, after, resp.T2UnixNS, resp.T3UnixNS)
+	}
+	// Defaults() configures a timesync server, so Offset A context rides along.
+	if resp.Server == nil {
+		t.Fatalf("server (Offset A) block missing")
+	}
+	if resp.Server.Host != "time.cloudflare.com" {
+		t.Errorf("server.host = %q", resp.Server.Host)
+	}
+}
+
+func TestTimeHandler_NoT1_AndProbeDisabled(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.TimeSync.Server = "" // probe off → no Offset A block
+	s := newTestServer(t, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/time", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d", w.Code)
+	}
+	var resp timeResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.T1UnixNS != 0 {
+		t.Errorf("absent t1 must echo 0, got %d", resp.T1UnixNS)
+	}
+	if resp.T2UnixNS == 0 || resp.T3UnixNS == 0 {
+		t.Errorf("t2/t3 must still be stamped without t1: t2=%d t3=%d", resp.T2UnixNS, resp.T3UnixNS)
+	}
+	if resp.Server != nil {
+		t.Errorf("server block must be omitted when timesync.server is empty; got %+v", resp.Server)
+	}
+}
+
+func TestTimeHandler_MethodNotAllowed(t *testing.T) {
+	s := newTestServer(t, config.Defaults())
+	req := httptest.NewRequest(http.MethodPost, "/time", nil)
+	w := httptest.NewRecorder()
+	s.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("POST /time = %d, want 405", w.Code)
+	}
 }
 
 func TestVersionHandler(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,6 +104,7 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("/health", s.handleHealth)
+	mux.HandleFunc("/time", s.handleTime)
 	mux.HandleFunc("/version", s.handleVersion)
 	mux.HandleFunc("/capabilities", s.handleCapabilities)
 	mux.HandleFunc("/actions/unload-model", s.requireToken(s.handleUnload))
@@ -122,6 +123,6 @@ func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	fmt.Fprintln(w, "rt-node-agent — see SPEC.md and docs/")
-	fmt.Fprintln(w, "read:    GET /health, GET /version, GET /capabilities, GET /metrics")
+	fmt.Fprintln(w, "read:    GET /health, GET /time, GET /version, GET /capabilities, GET /metrics")
 	fmt.Fprintln(w, "actions: POST /actions/unload-model, POST /actions/service")
 }

--- a/scripts/timesync/setup-timesync.sh
+++ b/scripts/timesync/setup-timesync.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+# setup-timesync.sh — stand up chrony for the RedTorch fleet's time sync.
+#
+# Topology:
+#   * ONE box is the local NTP "server" — it disciplines itself from public
+#     NTP over the WAN uplink (e.g. Starlink) and serves the LAN. It keeps
+#     serving at a usable stratum even if the uplink drops (`local stratum`).
+#   * EVERY node is a "client" — it disciplines its clock from the local
+#     server only (no internet needed on the nodes).
+#
+# Usage (run as root on each box):
+#   # on the NTP server box — pass the LAN/CIDR that may query it:
+#   sudo ./setup-timesync.sh server 10.0.0.0/24
+#   # (optionally append upstream NTP servers; defaults shown below)
+#   sudo ./setup-timesync.sh server 10.0.0.0/24 time.cloudflare.com 2.pool.ntp.org
+#
+#   # on every node — pass the NTP server's LAN IP/host:
+#   sudo ./setup-timesync.sh client 10.0.0.10
+#
+# After this runs, rt-node-agent measures the result automatically:
+#   * OS-sync fields (time_sync.source=chrony / skew_ms / stratum) populate
+#     from `chronyc tracking` on every box.
+#   * Point the agent's `timesync.server` at the NTP server's IP to also get
+#     Offset A (node↔reference) and feed GET /time / clock_offset_high.
+#
+# Idempotent: backs up any existing chrony.conf before writing. Exits
+# non-zero on any failure. Installs chrony via the host package manager.
+
+set -eu
+
+err()  { printf 'setup-timesync.sh: %s\n' "$*" >&2; exit 1; }
+info() { printf 'setup-timesync.sh: %s\n' "$*"; }
+
+[ "$(id -u)" = "0" ] || err "must run as root (chrony install + /etc writes)"
+
+ROLE="${1:-}"
+case "$ROLE" in
+  server)
+    LAN="${2:-}"
+    [ -n "$LAN" ] || err "server role needs a LAN CIDR, e.g. server 10.0.0.0/24"
+    shift 2  # drop 'server' + CIDR; any remaining args are upstream NTP hosts
+    UPSTREAM="$*"
+    [ -n "$UPSTREAM" ] || UPSTREAM="time.cloudflare.com 2.pool.ntp.org"
+    ;;
+  client)
+    NTP_SERVER="${2:-}"
+    [ -n "$NTP_SERVER" ] || err "client role needs the NTP server IP/host, e.g. client 10.0.0.10"
+    ;;
+  *)
+    err "first arg must be 'server' or 'client' (see header for usage)"
+    ;;
+esac
+
+# --- locate the host's chrony layout (Debian/Ubuntu vs RHEL/SUSE differ) ---
+install_chrony() {
+  if command -v chronyd >/dev/null 2>&1; then info "chrony already installed"; return; fi
+  if   command -v apt-get >/dev/null 2>&1; then apt-get update -qq && apt-get install -y chrony
+  elif command -v dnf     >/dev/null 2>&1; then dnf install -y chrony
+  elif command -v yum     >/dev/null 2>&1; then yum install -y chrony
+  elif command -v zypper  >/dev/null 2>&1; then zypper --non-interactive install chrony
+  else err "no supported package manager (apt/dnf/yum/zypper) — install chrony manually"
+  fi
+}
+
+# Debian/Ubuntu: /etc/chrony/chrony.conf + service 'chrony'.
+# RHEL/SUSE:     /etc/chrony.conf       + service 'chronyd'.
+conf_path() {
+  if [ -d /etc/chrony ]; then echo /etc/chrony/chrony.conf; else echo /etc/chrony.conf; fi
+}
+service_name() {
+  if systemctl list-unit-files 2>/dev/null | grep -q '^chrony\.service'; then echo chrony; else echo chronyd; fi
+}
+
+install_chrony
+CONF="$(conf_path)"
+SVC="$(service_name)"
+
+if [ -f "$CONF" ]; then
+  BAK="$CONF.bak.$(date +%s)"
+  cp "$CONF" "$BAK"
+  info "backed up existing config to $BAK"
+fi
+
+if [ "$ROLE" = "server" ]; then
+  {
+    echo "# Managed by rt-node-agent setup-timesync.sh (role: server)."
+    echo "# Disciplines from public NTP over the WAN uplink; serves the LAN."
+    for u in $UPSTREAM; do echo "server $u iburst"; done
+    echo "# Keep serving the LAN at a usable stratum if the uplink (Starlink) drops:"
+    echo "local stratum 10"
+    echo "allow $LAN"
+    echo "driftfile /var/lib/chrony/drift"
+    echo "makestep 1.0 3"
+    echo "rtcsync"
+  } > "$CONF"
+  info "wrote server config ($CONF): upstream='$UPSTREAM' allow=$LAN"
+else
+  {
+    echo "# Managed by rt-node-agent setup-timesync.sh (role: client)."
+    echo "# Disciplines from the local fleet NTP server only — no internet needed."
+    echo "server $NTP_SERVER iburst"
+    echo "driftfile /var/lib/chrony/drift"
+    echo "makestep 1.0 3"
+    echo "rtcsync"
+  } > "$CONF"
+  info "wrote client config ($CONF): server=$NTP_SERVER"
+fi
+
+systemctl enable "$SVC" >/dev/null 2>&1 || true
+systemctl restart "$SVC" || err "failed to (re)start $SVC — check 'journalctl -u $SVC'"
+info "$SVC restarted"
+
+# Give chrony a moment to make first contact, then show state.
+sleep 2
+info "--- chronyc tracking ---"
+chronyc tracking || true
+info "--- chronyc sources ---"
+chronyc -n sources || true
+
+info "done. rt-node-agent will now report time_sync.source=chrony on this box."
+[ "$ROLE" = "client" ] && info "remember: set the agent's timesync.server: $NTP_SERVER for Offset A + GET /time."
+exit 0

--- a/spec/SPEC.md
+++ b/spec/SPEC.md
@@ -190,12 +190,50 @@ Response:
 }
 ```
 
-- `now_unix_ns` is the node's wall clock at /health composition time, in nanoseconds since the Unix epoch. Always populated. **Primary cross-node comparison primitive:** the case-manager subtracts this from its own clock to compute a per-node offset (corrected by RTT/2 if it needs sub-ms precision).
+- `now_unix_ns` is the node's wall clock at /health composition time, in nanoseconds since the Unix epoch. Always populated. **Coarse cross-node comparison primitive:** the case-manager subtracts this from its own clock to compute a per-node offset (corrected by RTT/2 if it needs sub-ms precision). It is stamped before serialization, so its accuracy is bounded by the remaining compose+write tail — for sub-ms Offset B use `GET /time` instead.
 - `now_iso` is the same value rendered as RFC3339Nano UTC. Redundant with `now_unix_ns` but cheaper for log dashboards.
 - `tz_name` / `tz_offset_s` describe the node's configured local time zone.
 - `source` / `synced` / `skew_ms` / `stratum` / `last_update_s` come from the local OS sync daemon (chrony or systemd-timesyncd on Linux, sntp on darwin). Absent on Windows (no `w32tm` parser in v0.2.x) and on Linux hosts without either daemon.
 - `server` is the agent's own NTP probe against `timesync.server` from config (default `time.cloudflare.com`). 60s background cadence. `offset_ms` is **LOCAL minus SERVER** (positive = local is ahead of the reference). `error` populates instead when the last probe failed. Omitted entirely when `timesync.server: ""` in config.
 - `clock_skew_high` and `clock_offset_high` are two independent soft degraded reasons — the former reads the OS daemon's view, the latter reads the agent's own probe. Both can fire together when the local daemon and the external reference disagree.
+- `clock_offset_high` fires when `|offset_ms|` exceeds `timesync.offset_degraded_ms` (config, default `100`). Setting it to `0` (or negative) **disables** the reason — intended for measure-only fleets whose node clocks intentionally free-run (the offset is consumed/compensated by the backend rather than disciplined on the node), where a fixed threshold would otherwise latch permanently.
+
+### Two clock offsets (and which to use)
+
+The fleet exposes **two distinct offsets**, both meaningful:
+
+- **Offset A — node ↔ reference.** The node's clock vs. the configured `timesync.server` (an internal NTP box on air-gapped fleets). Measured by the agent's background probe; surfaced as `time_sync.server.offset_ms` (sign **node − reference**, positive = node ahead) and echoed in `GET /time`. Use for cross-node alignment: `node_i − node_j = A_i − A_j`.
+- **Offset B — caller ↔ node.** The calling backend's clock vs. the node's clock, measured by the backend at call time via `GET /time` (below). Use to interpret a node's reported timestamps directly in the backend's own clock frame.
+
+A and B are independent: A anchors every node to a shared reference; B anchors each node to *this* caller, which may run on a different reference (or none).
+
+### `GET /time` (v0.2.14 — caller↔node offset handshake)
+
+A minimal NTP-over-HTTP four-timestamp exchange for sub-millisecond **Offset B**, independent of `/health` composition cost. Open read endpoint (LAN trust, same posture as `/health`). The agent does no probing/allocation between the receive and transmit stamps, so the round-trip the caller measures is dominated by the network path.
+
+Request: `GET /time?t1=<unix_ns>` — `t1` is the caller's send time in Unix nanoseconds (optional; echoed as `0` when absent).
+
+```json
+{
+  "t1_unix_ns": 1749600000000000000,
+  "t2_unix_ns": 1749600000001234567,
+  "t3_unix_ns": 1749600000001240000,
+  "server": {
+    "host": "10.0.0.10",
+    "offset_ms": 1.23,
+    "rtt_ms": 0.4,
+    "stratum": 3,
+    "last_probe_age_s": 7,
+    "probe_interval_s": 60
+  }
+}
+```
+
+- `t2_unix_ns` is the node's receive time (handler entry); `t3_unix_ns` is the node's transmit time (just before the write). The caller records `t4` on receipt and computes, per RFC 5905 §8:
+  - `offset_ms = (((t2 − t1) + (t3 − t4)) / 2) / 1e6` — positive ⇒ **node ahead of caller** (add to the caller's clock to match the node).
+  - `rtt_ms = ((t4 − t1) − (t3 − t2)) / 1e6`.
+- `server` is the same cached probe snapshot as `/health.time_sync.server` (Offset A), folded in so a caller gets both offsets from one cheap call. Omitted when `timesync.server` is empty.
+- Older agents (pre-0.2.14) lack this endpoint — feature-detect via `capabilities.time_handshake_supported` and fall back to `time_sync.now_unix_ns` + the caller's own RTT/2.
 
 ### `degraded_reasons` contract
 


### PR DESCRIPTION
Follow-on to the v0.2.x time-alignment work. Defines and ships the **two clock offsets** the fleet needs, and the chrony tooling to discipline clocks against a self-hosted NTP server (Starlink-backed, air-gap-friendly).

## The two offsets

- **Offset A — node ↔ reference.** Already existed: the agent's NTP probe against `timesync.server`, surfaced as `time_sync.server.offset_ms` (sign: node − reference). Now also folded into `GET /time`.
- **Offset B — caller ↔ node.** New: the calling backend measures its own offset to a node via `GET /time`.

## `GET /time`

Minimal NTP-over-HTTP four-timestamp handshake. Open read endpoint (LAN trust). Agent stamps `t2` at handler entry and `t3` immediately before the write, **no work between**, so the caller gets sub-ms precision independent of `/health` cost.

```
GET /time?t1=<unix_ns>  →  { t1_unix_ns, t2_unix_ns, t3_unix_ns, server{…Offset A…} }
offset_ms = (((t2-t1)+(t3-t4))/2)/1e6   # + ⇒ node ahead of caller
rtt_ms    = ((t4-t1)-(t3-t2))/1e6
```

Advertised via `capabilities.time_handshake_supported`; older nodes lack it and the backend falls back to `time_sync.now_unix_ns` + RTT/2.

## Configurable `clock_offset_high`

New `timesync.offset_degraded_ms` (default **100**, preserving prior behavior; **0 disables**). For measure-only fleets whose clocks intentionally free-run, set `0` so the reason doesn't latch permanently.

## Chrony fleet tooling

`scripts/timesync/setup-timesync.sh` — one-liner per role:
- `server <lan-cidr>` — local NTP box: disciplines from public NTP over the WAN/Starlink uplink, serves the LAN, `local stratum 10` fallback if the uplink drops.
- `client <ntp-server-ip>` — nodes sync to the local server only (no internet needed).

Once chrony runs, the agent's existing OS-sync fields (`time_sync.source=chrony` / `skew_ms`) populate too. See [docs/timesync-fleet.md](docs/timesync-fleet.md).

## Contract / docs

Additive: new optional fields + new endpoint + new capability flag — the wire contract only grows. [spec/SPEC.md](spec/SPEC.md) (authoritative), new [docs/api/time.md](docs/api/time.md), config/capabilities/degraded-reasons docs updated.

## Verification

- `go build/vet/test ./...` green; new tests cover the `/time` handshake (window bounds, `t2≤t3`, `t1` echo, probe on/off, 405) and the configurable threshold (disabled + custom boundary).
- Live smoke test: handshake math + `server` Offset-A block + `time_handshake_supported` all confirmed over the wire.

**Deploy:** tag v0.2.14 + fleet redeploy; run `setup-timesync.sh` on the NTP box and nodes; set each node's `timesync.server` to the local NTP IP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)